### PR TITLE
处理swiper内存溢出

### DIFF
--- a/components/swiper/swiper.tsx
+++ b/components/swiper/swiper.tsx
@@ -166,6 +166,9 @@ const InternalSwiper: React.FC<SwiperProps> = (props: SwiperProps) => {
         });
     };
     getSwiperWidth();
+    return () => {
+          clearInterval(intervalId.current);
+    }
   }, []);
 
   // Seamless switching


### PR DESCRIPTION
在hook里关闭定时器，否则会导致内存溢出